### PR TITLE
Add additionsl DNS RR Types

### DIFF
--- a/ripe/atlas/sagan/dns.py
+++ b/ripe/atlas/sagan/dns.py
@@ -119,7 +119,6 @@ class Answer(ValidationMixin):
         self.raw_data  = data
         self.name      = self.ensure("Name",     str)
         self.ttl       = self.ensure("TTL",      int)
-        self.address   = self.ensure("Address",  str)
         self.type      = self.ensure("Type",     str)
         self.klass     = self.ensure("Class",    str)
         self.rd_length = self.ensure("RDlength", int)
@@ -127,6 +126,80 @@ class Answer(ValidationMixin):
     @property
     def resource_data_length(self):
         return self.rd_length
+
+
+class AAnswer(Answer):
+
+    def __init__(self, data):
+        Answer.__init__(self, data)
+        self.address   = self.ensure("Address",  str)
+
+AaaaAnswer = AAnswer
+
+
+class NsAnswer(Answer):
+
+    def __init__(self, data):
+        Answer.__init__(self, data)
+        self.target   = self.ensure("Target",  str)
+
+CnameAnswer = NsAnswer
+
+
+class MxAnswer(Answer):
+
+    def __init__(self, data):
+        Answer.__init__(self, data)
+        self.preference     = self.ensure("Preference",     int)
+        self.mail_exchanger = self.ensure("MailExchanger",  str)
+
+
+class SoaAnswer(Answer):
+
+    def __init__(self, data):
+        Answer.__init__(self, data)
+        self.master_server_name = self.ensure("MasterServerName", str)
+        self.maintainer_name    = self.ensure("MaintainerName",   str)
+        self.serial             = self.ensure("Serial",           int)
+        self.refresh            = self.ensure("Refresh",          int)
+        self.retry              = self.ensure("Retry",            int)
+        self.expire             = self.ensure("Expire",           int)
+        self.negative_ttl       = self.ensure("NegativeTtl",      int)
+
+    @property
+    def mname(self):
+        return self.master_server_name
+
+    @property
+    def rname(self):
+        return self.maintainer_name
+
+    @property
+    def minimum(self):
+        return self.negative_ttl
+
+    @property
+    def nxdomain(self):
+        return self.negative_ttl
+
+
+class DsAnswer(Answer):
+    def __init__(self, data):
+        Answer.__init__(self, data)
+        self.tag            = self.ensure("Tag",           int)
+        self.algorithm      = self.ensure("Algorithm",     int)
+        self.digest_type    = self.ensure("DigestType",    int)
+        self.delegation_key = self.ensure("DelegationKey", str)
+
+
+class DnskeyAnswer(Answer):
+
+    def __init__(self, data):
+        Answer.__init__(self, data)
+        self.flags       = self.ensure("Flags",      int)
+        self.algorithm   = self.ensure("Algorithm",  int)
+        self.protocol    = self.ensure("Protocol",   int)
+        self.key         = self.ensure("Key",        str)
 
 
 class Authority(ValidationMixin):
@@ -178,6 +251,16 @@ class Message(ValidationMixin):
         self.authorities = []
         self.additionals = []
 
+        answer_class = { 
+                'A'      : AAnswer, 
+                'AAAA'   : AaaaAnswer, 
+                'NS'     : NsAnswer,
+                'CNAME'  : CnameAnswer,
+                'MX'     : MxAnswer,
+                'SOA'    : SoaAnswer,
+                'DS'     : DsAnswer,
+                'DNSKEY' : DnskeyAnswer}
+
         if "EDNS0" in self.raw_data:
             self.edns0 = Edns0(self.raw_data["EDNS0"])
 
@@ -185,7 +268,8 @@ class Message(ValidationMixin):
             self.questions.append(Question(question))
 
         for answer in self.raw_data.get("AnswerSection", []):
-            self.answers.append(Answer(answer))
+            self.answers.append(
+                    answer_class.get(answer['Type'], Answer)(answer))
 
         for authority in self.raw_data.get("AuthoritySection", []):
             self.authorities.append(Authority(authority))


### PR DESCRIPTION
This compliments https://github.com/RIPE-NCC/ripe.atlas.sagan/pull/26 adding additional answer classes for   rr types MX, AAAA, CNAME, DNSKEY, DS and SOA
