### PR TITLE
remove arrow parts from documentation since it's deprecated nowdays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ Every result type has its own properties, with a few common between all types.
 
 Specifically, these attributes exist on all ``*Result`` objects:
 
--  ``created`` An arrow object (like datetime, but better) of the
+-  ``created`` An datetime object of the
    ``timestamp`` field
 -  ``measurement_id``
 -  ``probe_id``
@@ -175,7 +175,6 @@ What it requires
 As you might have guessed, with all of this magic going on under the hood, there
 are a few dependencies:
 
--  `arrow`_
 -  `pyOpenSSL`_ (Optional: see "Troubleshooting" above)
 -  `python-dateutil`_
 -  `pytz`_
@@ -231,7 +230,6 @@ But why "`Sagan`_"? The RIPE Atlas team decided to name all of its modules after
 explorers, and what better name for a parser than that of the man who spent
 decades reaching out to the public about the wonders of the cosmos?
 
-.. _arrow: https://pypi.python.org/pypi/arrow
 .. _pyOpenSSL: https://pypi.python.org/pypi/pyOpenSSL
 .. _python-dateutil: https://pypi.python.org/pypi/python-dateutil
 .. _pytz: https://pypi.python.org/pypi/pytz

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,6 @@ Requirements
 As you might have guessed, with all of the magic going on under the hood, there
 are a few dependencies:
 
-* `arrow`_
 * `pyOpenSSL`_
 * `python-dateutil`_
 * `pytz`_
@@ -21,7 +20,6 @@ Additionally, we recommend that you also install `ujson`_ as it will speed up
 the JSON-decoding step considerably, and `sphinx`_ if you intend to build the
 documentation files for offline use.
 
-.. _arrow: https://pypi.python.org/pypi/arrow/
 .. _pyOpenSSL: https://pypi.python.org/pypi/pyOpenSSL/
 .. _python-dateutil: https://pypi.python.org/pypi/python-dateutil/
 .. _pytz: https://pypi.python.org/pypi/pytz/

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -15,7 +15,7 @@ All measurement results have a few common properties.
 Property               Type      Explanation
 =====================  ========  ================================================================
 raw_data               dict      The entire measurement result, as-is from `json.loads()`
-created                arrow     The time at which this result was initiated
+created                datetime  The time at which this result was initiated
 created_timestamp      int       A Unix timestamp value for the ``created`` attribute
 measurement_id         int
 probe_id               int
@@ -26,12 +26,6 @@ is_malformed           bool      Whether the result (or related portion thereof)
 is_error               bool      Whether or not there were errors in parsing/handling this result
 error_message          str       If the result is an error, the message string is in here
 =====================  ========  ================================================================
-
-* Note that an ``arrow`` object is essentially a ``datetime`` object with some
-  additional magic.  If you're curious as to the nature of that magic, `the Arrow website`_
-  should get you started.
-
-.. _the Arrow website: http://crsmithdev.com/arrow/
 
 
 .. _ping:


### PR DESCRIPTION
Florian found out that there was a mismatch between setup.py and docs about arrow. It seems we don't use arrow anymore (changeslog mentions also that we dropped usage), so I remove it from the docs to avoid confusion.