### PR TITLE
pep8 + python3 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* 1.1.9
+    * Updated the `parse_abuf` script to support Python3.
 * 1.1.8
     * Handle case where a traceroute result might not have ``dst_addr`` field.
 * 1.1.7

--- a/ripe/atlas/sagan/version.py
+++ b/ripe/atlas/sagan/version.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.1.8"
+__version__ = "1.1.9"

--- a/scripts/parse_abuf
+++ b/scripts/parse_abuf
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import base64
 import json
@@ -7,6 +9,7 @@ import string
 import sys
 
 from ripe.atlas.sagan.helpers.abuf import AbufParser
+
 
 def main(args):
 
@@ -22,15 +25,15 @@ def main(args):
     line = sys.stdin.readline()
 
     if args.verbosity > 2:
-        print "#inputline:\n#", line, "#end inputline-----"
+        print("#inputline:\n#", line, "#end inputline-----")
 
     if line[:1] == "{" and line[-2:-1] == "}":
 
-        # json encoded data (RIPE Atlas measurment)
+        # JSON encoded data (RIPE Atlas measurement)
         while line:
 
-            if args.verbosity >1:
-                print "#json line:\n# ", line, "#end json line-----"
+            if args.verbosity > 1:
+                print("#json line:\n# ", line, "#end json line-----")
 
             result['line_count'] += 1
             result['errorFindingDecodingabuf'] = 0
@@ -39,43 +42,41 @@ def main(args):
             try:
 
                 data = json.loads(line)
-                if data.has_key('result'):
-                    if data['result'].has_key('abuf'):
+                if 'result' in data:
+                    if 'abuf' in data['result']:
                         babuf = None
-                        if args.verbosity >1:
-                             print "#b64buf:\n#",data['result']['abuf'],"\n#end b64buf------"
+                        if args.verbosity > 1:
+                            print(
+                                "#b64buf:\n#",
+                                data['result']['abuf'],
+                                "\n#end b64buf------"
+                            )
                         try:
                             babuf = base64.b64decode(data['result']['abuf'])
                         except Exception:
-                            result['b64decode_failures'] += 1;
+                            result['b64decode_failures'] += 1
 
                         if babuf:
-                            adata  = AbufParser.parse(babuf, options) #, result)
+                            adata = AbufParser.parse(babuf, options)
                             if adata:
-                                if data.has_key('ERROR'):
+                                if 'ERROR' in data:
                                     result['decodedabufs_with_ERROR'] += 1
-                                data['DnsReply']= adata
+                                data['DnsReply'] = adata
 
             except Exception:
 
                 line = sys.stdin.readline()
                 continue
-                error = []
-                e = ("Error finding/decoding abuf")
-                error.append(e)
-                print "error:", error
-                data['ERROR'] = error
-                result['errorFindingDecodingabuf'] += 1
 
             if args.formattedJSON:
-                print json.dumps(
+                print(json.dumps(
                     data,
                     sort_keys=True,
                     indent=4,
                     separators=(',', ': ')
-                )
+                ))
             else:
-                print json.dumps(data)
+                print(json.dumps(data))
 
             line = sys.stdin.readline()
 
@@ -83,44 +84,49 @@ def main(args):
 
         while line:
             if args.verbosity > 1:
-                print "#b64 encoded abuf line:\n#", line, "#end b64 encoded abuf line-----"
+                print(
+                    "#b64 encoded abuf line:\n#",
+                    line,
+                    "#end b64 encoded abuf line-----"
+                )
             result['line_count'] += 1
 
             try:
                 babuf = base64.b64decode(line)
             except Exception:
-                result['b64decode_failures'] += 1;
+                result['b64decode_failures'] += 1
                 line = sys.stdin.readline()
                 continue
 
-            data  = AbufParser.parse(babuf, options)
+            data = AbufParser.parse(babuf, options)
 
             if data:
-                if data.has_key('ERROR'):
+                if 'ERROR' in data:
                     result['decodedabufs_with_ERROR'] += 1
                 if args.formattedJSON:
-                    print json.dumps(
+                    print(json.dumps(
                         data,
                         sort_keys=True,
                         indent=4,
                         separators=(',', ': ')
-                    )
+                    ))
                 else:
-                    print json.dumps(data)
+                    print(json.dumps(data))
             else:
                 result['abufdecode_failures'] += 1
 
             line = sys.stdin.readline()
 
     if args.verbosity:
-        print "#======== results:\n#",
+        print("#======== results:\n#", end="")
         lines = json.dumps(
             result,
             sort_keys=True,
             indent=4,
             separators=(',', ': ')
         )
-        print string.replace(lines, "\n", "\n#")  # We want this to be comments lines on stdout
+        # We want this to be comment lines on stdout
+        print(string.replace(lines, "\n", "\n#"))
 
     sys.stdout.flush()
 
@@ -137,14 +143,14 @@ if __name__ == '__main__':
     parser.add_argument('-dau',  '--DO_Authority',  default=0, action="count")
     parser.add_argument('-do',   '--DO_Options',    default=0, action="count")
     parser.add_argument('-dall', '--DO_All',        default=0, action="count")
-    args = parser.parse_args()
+    arguments = parser.parse_args()
 
-    if args.DO_All:
-        args.DO_Header     = 1
-        args.DO_Question   = 1
-        args.DO_Answer     = 1
-        args.DO_Additional = 1
-        args.DO_Authority  = 1
-        args.DO_Options    = 1
+    if arguments.DO_All:
+        arguments.DO_Header = 1
+        arguments.DO_Question = 1
+        arguments.DO_Answer = 1
+        arguments.DO_Additional = 1
+        arguments.DO_Authority = 1
+        arguments.DO_Options = 1
 
-    sys.exit(main(args))
+    sys.exit(main(arguments))


### PR DESCRIPTION
As per Jan's recommendations regarding getting this package into Fedora, I've added Python3 support to the `parse_abuf` script.

I think it'd be a good idea for @phicoh to take a look at this though before we consider this ready to merge, since he wrote it and has the most experience with it.