### PR TITLE
Do the bulk of the validity checking for ParsingDict.keys() at class …

### DIFF
--- a/ripe/atlas/sagan/base.py
+++ b/ripe/atlas/sagan/base.py
@@ -19,7 +19,7 @@ import pytz
 from calendar import timegm
 from datetime import datetime
 
-from .helpers.compatibility import string
+from .helpers.compatibility import string, with_metaclass
 
 # Try to use ujson if it's available
 try:
@@ -76,7 +76,7 @@ class ParsingDictMetaclass(type):
         return new_cls
 
 
-class ParsingDict(object):
+class ParsingDict(with_metaclass(ParsingDictMetaclass, object)):
     """
     A handy container for methods we use for validation in the various result
     classes.
@@ -99,8 +99,6 @@ class ParsingDict(object):
         "TCP":  PROTOCOL_TCP,
         "T":    PROTOCOL_TCP,
     }
-
-    __metaclass__ = ParsingDictMetaclass
 
     def __init__(self, **kwargs):
 

--- a/ripe/atlas/sagan/helpers/compatibility.py
+++ b/ripe/atlas/sagan/helpers/compatibility.py
@@ -22,3 +22,38 @@ try:
 except NameError:
     string = str  # Python3
 
+
+def with_metaclass(meta, *bases):
+    """
+    Function from jinja2/_compat.py. License: BSD.
+
+    Use it like this::
+
+        class BaseForm(object):
+            pass
+
+        class FormType(type):
+            pass
+
+        class Form(with_metaclass(FormType, BaseForm)):
+            pass
+
+    This requires a bit of explanation: the basic idea is to make a
+    dummy metaclass for one level of class instantiation that replaces
+    itself with the actual metaclass.  Because of internal type checks
+    we also need to make sure that we downgrade the custom metaclass
+    for one level to something closer to type (that's why __call__ and
+    __init__ comes back from type etc.).
+
+    This has the advantage over six.with_metaclass of not introducing
+    dummy classes into the final MRO.
+    """
+    class metaclass(meta):
+        __call__ = type.__call__
+        __init__ = type.__init__
+
+        def __new__(cls, name, this_bases, d):
+            if this_bases is None:
+                return type.__new__(cls, name, (), d)
+            return meta(name, bases, d)
+    return metaclass('temporary_class', None, {})


### PR DESCRIPTION
Currently ParsingDict.keys() checks every single attribute in dir(obj) to see if it should return it. This includes actually getattr()ing every attribute and checking whether it is callable(). Since Sagan objects do not have functions as attributes except when they are defined on the class, we can do this check once at class instantiation time. We still have to filter out underscore-private attributes in keys(), but that's nowhere near as expensive.

My use case for this change is the timetravel API as called by the map on the RIPE Atlas measurement detail page, where for a builtin traceroute measurement (with three layers of nested ParsingDicts: Traceroute -> Hop -> Packet) it can cut API response time by up to a factor of 3.