### PR TITLE
Allow faster traceroute parsing with optional minimalist hop-parsing …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
-
+* 1.1.10
+    * Added a `parse_all_hops` kwarg to the Traceroute class to tell Sagan to stop parsing Hops and Packets once we have all of the last hop statistics (default=True)
+    * Remove dependency on IPy: we were using it for IPv6 canonicalization, but all IPv6 addresses in results should be in canonical form to start with.
 * 1.1.9
     * Removed the `parse_abuf` script because no one was using it and its
       Python3 support was suspect anyway.

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,6 @@ are a few dependencies:
 -  `pyOpenSSL`_ (Optional: see "Troubleshooting" above)
 -  `python-dateutil`_
 -  `pytz`_
--  `IPy`_
 
 Additionally, we recommend that you also install `ujson`_ as it will speed up
 the JSON-decoding step considerably, and `sphinx`_ if you intend to build the
@@ -233,7 +232,6 @@ decades reaching out to the public about the wonders of the cosmos?
 .. _pyOpenSSL: https://pypi.python.org/pypi/pyOpenSSL
 .. _python-dateutil: https://pypi.python.org/pypi/python-dateutil
 .. _pytz: https://pypi.python.org/pypi/pytz
-.. _IPy: https://pypi.python.org/pypi/IPy/
 .. _ujson: https://pypi.python.org/pypi/ujson
 .. _sphinx: https://pypi.python.org/pypi/Sphinx
 .. _Read the Docs: http://ripe-atlas-sagan.readthedocs.org/en/latest/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,6 @@ are a few dependencies:
 * `pyOpenSSL`_
 * `python-dateutil`_
 * `pytz`_
-* `IPy`_
 
 Additionally, we recommend that you also install `ujson`_ as it will speed up
 the JSON-decoding step considerably, and `sphinx`_ if you intend to build the
@@ -23,7 +22,6 @@ documentation files for offline use.
 .. _pyOpenSSL: https://pypi.python.org/pypi/pyOpenSSL/
 .. _python-dateutil: https://pypi.python.org/pypi/python-dateutil/
 .. _pytz: https://pypi.python.org/pypi/pytz/
-.. _IPy: https://pypi.python.org/pypi/IPy/
 .. _ujson: https://pypi.python.org/pypi/ujson/
 .. _sphinx: https://pypi.python.org/pypi/Sphinx/
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -108,7 +108,7 @@ It is also possible to supply the following parameter to control parsing of Trac
 ============== ==== ======= ===========
 Parameter      Type Default Explanation
 ============== ==== ======= ===========
-parse_all_hops bool True    Set to ``False`` to stop parsing ``Hop`` objects after ``last_median_rtt``, ``destination_ip_responded``, ``last_hop_responded``, ``is_success`` and ``last_hop_errors`` have been set. This will cause ``hops`` to only contain the last ``Hop``.
+parse_all_hops bool True    Set to ``False`` to stop parsing ``Hop`` objects after the ``last_*`` properties (see above) have been set. This will cause ``hops`` to only contain the last ``Hop``.
 ============== ==== ======= ===========
 
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -93,7 +93,7 @@ end_time_timestamp        int       A Unix timestamp for the ``end_time`` attrib
 paris_id                  int
 size                      int       The packet size
 protocol                  str       One of ``ICMP``, ``TCP``, ``UDP``
-hops                      list      A list of :ref:`traceroute-hop` objects
+hops                      list      A list of :ref:`traceroute-hop` objects. If the ``parse_all_hops`` parameter is ``False``, this will only contain the last hop.
 total_hops                int       The total number of hops
 ip_path                   list      A list of dicts containing the IPs at each hop. This is just for convenience as all of these values are accessible via the :ref:`traceroute-hop` and :ref:`traceroute-packet` objects.
 last_median_rtt           float     The median value of all RTTs from the last successful hop
@@ -102,6 +102,14 @@ last_hop_responded        bool      Set to ``True`` if the last hop was a respon
 is_success                bool      Set to ``True`` if the traceroute finished successfully
 last_hop_errors           list      A list of last hop's errors
 ========================  ========  ===================================================================================
+
+It is also possible to supply the following parameter to control parsing of Traceroute results:
+
+============== ==== ======= ===========
+Parameter      Type Default Explanation
+============== ==== ======= ===========
+parse_all_hops bool True    Set to ``False`` to stop parsing ``Hop`` objects after ``last_median_rtt``, ``destination_ip_responded``, ``last_hop_responded``, ``is_success`` and ``last_hop_errors`` have been set. This will cause ``hops`` to only contain the last ``Hop``.
+============== ==== ======= ===========
 
 
 .. _traceroute-hop:

--- a/ripe/atlas/sagan/version.py
+++ b/ripe/atlas/sagan/version.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.1.9"
+__version__ = "1.1.10"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ name = "ripe.atlas.sagan"
 install_requires = [
     "python-dateutil",
     "pytz",
-    "IPy",
 ]
 
 tests_require = ["nose"]


### PR DESCRIPTION
* This adds support for a "parse_all_hops=False" option to Traceroute.__init__ which will start at the last hop, and work backwards only as long as is necessary to fill in the various Traceroute-level attributes, such as last_hop_responded, destination_ip_responded and last_median_rtt. This is useful for cases when we don't need access to the actual hops, because it saves on a lot of object initialization for all of the extra Hop and Packet objects.

* The request also removes the use of IPy to compare the intended destination address with the origin reported in the last hop, because these should always be in canonical form. I spoke with @PhilipHomburg who says he would consider it a bug if there was ever a difference in IPv6 address representation within the traceroute results.