### PR TITLE
Hop should return a string when calling __str__

### DIFF
--- a/ripe/atlas/sagan/traceroute.py
+++ b/ripe/atlas/sagan/traceroute.py
@@ -112,7 +112,7 @@ class Hop(ParsingDict):
         self.median_rtt = Result.calculate_median(packet_rtts)
 
     def __str__(self):
-        return self.index
+        return str(self.index)
 
 
 class TracerouteResult(Result):


### PR DESCRIPTION
Currently the Hop class returns an integer when __str__ is called. This causes an error if Hop is printed:

```
TypeError: __str__ returned non-string (type int)
```