### PR TITLE
handle case where the result contains an error in the "error" field

### DIFF
--- a/ripe/atlas/sagan/base.py
+++ b/ripe/atlas/sagan/base.py
@@ -208,6 +208,9 @@ class Result(ParsingDict):
         if "err" in self.raw_data:
             self._handle_error(self.raw_data["err"])
 
+        if "error" in self.raw_data:
+            self._handle_error(self.raw_data["error"])
+
     def __repr__(self):
         return "Measurement #{measurement}, Probe #{probe}".format(
             measurement=self.measurement_id,

--- a/ripe/atlas/sagan/base.py
+++ b/ripe/atlas/sagan/base.py
@@ -208,9 +208,6 @@ class Result(ParsingDict):
         if "err" in self.raw_data:
             self._handle_error(self.raw_data["err"])
 
-        if "error" in self.raw_data:
-            self._handle_error(self.raw_data["error"])
-
     def __repr__(self):
         return "Measurement #{measurement}, Probe #{probe}".format(
             measurement=self.measurement_id,

--- a/ripe/atlas/sagan/ssl.py
+++ b/ripe/atlas/sagan/ssl.py
@@ -207,6 +207,9 @@ class SslResult(Result):
         self.response_time = self.ensure("rt", float)
         self.time_to_connect = self.ensure("ttc", float)
 
+        if "error" in self.raw_data:
+            self._handle_error(self.raw_data["error"])
+
         # Older versions used named ports
         if self.port is None and self.raw_data.get("dst_port") == "https":
             self.port = 443

--- a/tests/ssl.py
+++ b/tests/ssl.py
@@ -392,3 +392,7 @@ def test_san_extension():
     ext = result.certificates[0].extensions
     assert(ext and len(ext['subjectAltName'])==54)
 
+def test_ssl_error():
+    result = Result.get('{"dst_name": "example.com","dst_port": "443","error": "address not allowed","from":"10.1.1.1","fw": 4760,"group_id": 1234567,"lts": 10,"msm_id": 1234567,"msm_name": "SSLCert","prb_id": 9999,"timestamp": 1495451999,"type": "sslcert"}')
+    assert(result.is_error is True)
+    assert(result.error_message == "address not allowed")


### PR DESCRIPTION
Apparently the probe firmware reports errors not only in "err" and "dnserr" field, but "error" as well. This tiny patch adds the handler for this.