### PR TITLE
Drop Python 3.3 & add 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
 install:
-  - pip install tox
+  - pip install .
+  - pip install nose
 script:
-  tox
+  - python setup.py test
 sudo: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py33,py34,py35,py36
+envlist=py27,py34,py35,py36
 
 [testenv]
 commands=python setup.py test []


### PR DESCRIPTION
Were it up to me, I'd drop 2.7 as well, but I figure that's a hard-sell at this point ;-)

Apparently, there's some [known issues](https://github.com/travis-ci/travis-ci/issues/4794) with how Travis handles multiple Python environments.  So after some poking I realised that the testing strategy we were using was redundant anyway: We were using tox to build python environments in each Travis container -- containers that were already being spun up for specific Python versions.

This commit drops the use of tox in Travis (though it keeps the `tox.ini` file for local development & testing) and instead instructs Travis to run the tests natively after installing Sagan in the container.