### PR TITLE
Fixed type of Traceroute ip_path property

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -95,7 +95,7 @@ size                      int       The packet size
 protocol                  str       One of ``ICMP``, ``TCP``, ``UDP``
 hops                      list      A list of :ref:`traceroute-hop` objects. If the ``parse_all_hops`` parameter is ``False``, this will only contain the last hop.
 total_hops                int       The total number of hops
-ip_path                   list      A list of dicts containing the IPs at each hop. This is just for convenience as all of these values are accessible via the :ref:`traceroute-hop` and :ref:`traceroute-packet` objects.
+ip_path                   list      A list of list containing the IPs at each hop. This is just for convenience as all of these values are accessible via the :ref:`traceroute-hop` and :ref:`traceroute-packet` objects.
 last_median_rtt           float     The median value of all RTTs from the last successful hop
 destination_ip_responded  bool      Set to ``True`` if the last hop was a response from the destination IP
 last_hop_responded        bool      Set to ``True`` if the last hop was a response at all


### PR DESCRIPTION
Solves #87. The Traceroute ip_path property is not "a list of dicts", as indicated by the [existing](https://github.com/RIPE-NCC/ripe.atlas.sagan/blob/f6fc10c8f55b73a3229f4f5f5beea4d771994913/docs/types.rst#traceroute) documentation, but a list of lists.