### PR TITLE
Use named loggers

### DIFF
--- a/ripe/atlas/sagan/base.py
+++ b/ripe/atlas/sagan/base.py
@@ -28,6 +28,9 @@ except ImportError:
     import json
 
 
+log = logging.getLogger(__name__)
+
+
 class ResultParseError(Exception):
     pass
 
@@ -138,14 +141,14 @@ class ParsingDict(object):
         if self._on_malformation == self.ACTION_FAIL:
             raise ResultParseError(message)
         elif self._on_malformation == self.ACTION_WARN:
-            logging.warning(message)
+            log.warning(message)
         self.is_malformed = True
 
     def _handle_error(self, message):
         if self._on_error == self.ACTION_FAIL:
             raise ResultError(message)
         elif self._on_error == self.ACTION_WARN:
-            logging.warning(message)
+            log.warning(message)
         self.is_error = True
         self.error_message = message
 

--- a/ripe/atlas/sagan/ssl.py
+++ b/ripe/atlas/sagan/ssl.py
@@ -25,7 +25,7 @@ try:
     from cryptography.hazmat.backends import openssl
     from cryptography.hazmat.primitives import hashes
 except ImportError:
-    logging.warning(
+    logging.getLogger(__name__).warning(
         "cryptography module is not installed, without it you cannot parse SSL "
         "certificate measurement results"
     )

--- a/ripe/atlas/sagan/traceroute.py
+++ b/ripe/atlas/sagan/traceroute.py
@@ -20,6 +20,9 @@ from calendar import timegm
 from .base import Result, ParsingDict
 
 
+log = logging.getLogger(__name__)
+
+
 class IcmpHeader(ParsingDict):
     """
     But why did we stop here?  Why not go all the way and define subclasses for
@@ -148,14 +151,14 @@ class TracerouteResult(Result):
 
     @property
     def last_rtt(self):
-        logging.warning(
+        log.warning(
             '"last_rtt" is deprecated and will be removed in future versions. '
             'Instead, use "last_median_rtt".')
         return self.last_median_rtt
 
     @property
     def target_responded(self):
-        logging.warning(
+        log.warning(
             'The "target_responded" property is deprecated and will be removed '
             'in future versions.  Instead, use "destination_ip_responded".'
         )


### PR DESCRIPTION
The library currently uses the root logger, which prevents
applications from separating their logs from the library's.

With this change, applications can silence or redirect sagan
logs by reconfiguring the "ripe" logger.  In particular, the
following will print only `FATAL` messages from sagan:

```
def main():
    ripe_logger = logging.getLogger("ripe")
    ripe_logger.setLevel(logging.FATAL)
    ...
```

close https://github.com/RIPE-NCC/ripe-atlas-sagan/issues/89